### PR TITLE
Remove variable metadata

### DIFF
--- a/doc/etiquetdo.ipynb
+++ b/doc/etiquetdo.ipynb
@@ -41,7 +41,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46186ff3adf74fcaa9289def4dc33eb5",
+       "model_id": "3b288c0024154b52bbaf7f686d2a0289",
        "version_major": 2,
        "version_minor": 0
       },
@@ -58,8 +58,7 @@
      "output_type": "stream",
      "text": [
       "observer not running\n",
-      "start watching files with suffix '.csv' in folder './files/data_raw/'.\n",
-      "Stopped watching\n"
+      "start watching files with suffix '.csv' in folder './files/data_raw/'.\n"
      ]
     }
    ],
@@ -79,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,14 +109,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "File with name './files/data_raw/with_metadata_printed.csv' was created.\n"
+      "File with name './files/data_raw/with_metadata_printed.csv' was created."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -128,23 +134,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "observer not running\n"
+      "Stopped watching\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -162,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,13 +185,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b8e8167da0264258ba29417e2218fdf2",
+       "model_id": "af9f6a59d32d41e9ac72d99c7b23b493",
        "version_major": 2,
        "version_minor": 0
       },
@@ -193,7 +199,7 @@
        "Tab(children=(VBox(children=(Dropdown(description='Yaml templates', layout=Layout(flex='flex-grow', width='400…"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -202,7 +208,8 @@
      "output_type": "stream",
      "text": [
       "observer not running\n",
-      "start watching files with suffix '.csv' in folder './files/data_raw/'.\n"
+      "start watching files with suffix '.csv' in folder './files/data_raw/'.\n",
+      "Stopped watching\n"
      ]
     }
    ],
@@ -216,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/doc/etiquetdo_converter.ipynb
+++ b/doc/etiquetdo_converter.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7472bbba047548a1b0fc9fe32f29617e",
+       "model_id": "de53e24a023a4e94bc420e4e8a8069dd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,49 +94,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['./files/data_raw/for_conversion_101.csv',\n",
-       " './files/data_raw/for_conversion_102.csv',\n",
+       "['./files/data_raw/for_conversion_102.csv',\n",
+       " './files/data_raw/for_conversion_101.csv',\n",
        " './files/data_raw/for_conversion_103.csv']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "app.list_options.get_file_options()\n",
-    "app.list_options."
+    "app.list_options.get_file_options()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.list_options.reset_options([])"
+    "app.list_options.sync_options()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/etiquetado_voila/apps/pieces.py
+++ b/etiquetado_voila/apps/pieces.py
@@ -38,8 +38,9 @@ class ListOptions:
 
     def add_option(self, option):
         new_options = [item for item in self.option_selector.options]
-        if not option in new_options:
-            new_options.append(option)
+        if new_options:
+            if not option in new_options:
+                new_options.append(option)
         self.reset_options(new_options)
 
     def remove_option(self, option):

--- a/etiquetado_voila/apps/pieces.py
+++ b/etiquetado_voila/apps/pieces.py
@@ -38,7 +38,8 @@ class ListOptions:
 
     def add_option(self, option):
         new_options = [item for item in self.option_selector.options]
-        new_options.append(option)
+        if not option in new_options:
+            new_options.append(option)
         self.reset_options(new_options)
 
     def remove_option(self, option):


### PR DESCRIPTION
Remove the possibility to use variable metadata, since this is not required in the basic app.

We should reimplement this possibility again later.